### PR TITLE
Added dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,20 @@ setup(
       'Topic :: Scientific/Engineering :: Artificial Intelligence'
     ],
     include_package_data = True,
-#    install_requires = [
-#      'numpy',
-#      'scipy',
-#      'Sphinx',
-#      'numpydoc',
-#    ],
-#    tests_require = [
-#      'nose',
-#    ]
+    install_requires = [
+      'numpy',
+      'scipy',
+    ],
+    tests_require = [
+      'nose',
+    ],
+    extras_require = {
+        'docs': [
+          'Sphinx',
+          'numpydoc',
+        ],
+        'tests': [
+          'nose',
+        ],
+    },
 )


### PR DESCRIPTION
A setup.py without dependencies is a bit useless as PIP cannot go and install a working stack itself. Hence you should have the deps in there (they were, but commented out)
